### PR TITLE
Option to open results buffer below code buffer instead of above

### DIFF
--- a/plugin/ruby_runner.vim
+++ b/plugin/ruby_runner.vim
@@ -18,7 +18,10 @@ function! s:RunRuby()
     exe "keepjumps ".bufwinnr(t:rrbufnr)."wincmd W"
     exe 'normal ggdG'
   else
-    exe "keepjumps silent! new"
+    if (!exists("g:RubyRunner_open_below"))
+      let g:RubyRunner_open_below = 0
+    endif
+    exe "keepjumps silent!" . (g:RubyRunner_open_below == 1 ? " below" : "") . " new"
     let t:rrbufnr=bufnr('%')
   end
 


### PR DESCRIPTION
add g:RubyRunner_open_below option to open result buffer below code buffer

add the following to your .vimrc to enable it:

let g:RubyRunner_open_below = 1

P.S. Thanks for a nice plugin!
