### PR TITLE
Resize the output buffer window when it is created

### DIFF
--- a/doc/ruby_runner.txt
+++ b/doc/ruby_runner.txt
@@ -51,6 +51,10 @@ buffer, do:
 
     let g:RubyRunner_open_below = 1
 
+If you'd like the output buffer's window to be a different size, do:
+
+    let g:RubyRunner_window_size = 10
+
 ================================================================================
 CAVEATS                                                      *RubyRunnerCaveats*
 

--- a/plugin/ruby_runner.vim
+++ b/plugin/ruby_runner.vim
@@ -29,6 +29,9 @@ function! s:RunRuby()
     exec 'normal ggdG'
   else
     exec 'keepjumps silent!' (g:RubyRunner_open_below == 1 ? 'below' : '') 'new'
+    if (exists("g:RubyRunner_window_size"))
+      exec 'resize' g:RubyRunner_window_size
+    endif
     let t:rrbufnr=bufnr('%')
   end
 


### PR DESCRIPTION
I added an option to automatically resize the output buffer window when it is created.

To set the window height for the output buffer to 10 lines, add this to your .vimrc:

```
let g:RubyRunner_window_size = 10
```

If the variable does not exist, it will open at 50% height as it does now.
